### PR TITLE
Fix concurrency problem during the classification of instances

### DIFF
--- a/openml-caret/src/main/java/com/feedzai/openml/caret/CaretModelLoader.java
+++ b/openml-caret/src/main/java/com/feedzai/openml/caret/CaretModelLoader.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import static com.feedzai.openml.r.ProviderRObject.INSTANCE_VARIABLE;
 import static com.feedzai.openml.r.ProviderRObject.MODEL_VARIABLE;
 
 /**
@@ -75,12 +74,12 @@ public class CaretModelLoader extends GenericRModelLoader {
                 "  temp_Model <- readRDS('%s')\n" +
                 "  return(temp_Model)\n" +
                 "}";
-        final String getClassDistributionFn = "%s <- function() {\n" +
-                "  temp_Distribution <- predict(%s, %s, type='prob')\n" +
+        final String getClassDistributionFn = "%s <- function(instance) {\n" +
+                "  temp_Distribution <- predict(%s, instance, type='prob')\n" +
                 "  return(temp_Distribution)\n" +
                 "}";
-        final String getClassificationFn = "%s <- function() {\n" +
-                "  temp_Classification <- predict(%s, %s, type='raw')\n" +
+        final String getClassificationFn = "%s <- function(instance) {\n" +
+                "  temp_Classification <- predict(%s, instance, type='raw')\n" +
                 "  return(temp_Classification)\n" +
                 "}";
 
@@ -91,12 +90,10 @@ public class CaretModelLoader extends GenericRModelLoader {
                                                LoadModelUtils.getModelFilePath(modelFilePath)));
             rConnection.voidEval(String.format(getClassDistributionFn,
                                                ProviderRObject.CLASS_DISTRIBUTION_FN.getName(),
-                                               MODEL_VARIABLE.getName(),
-                                               INSTANCE_VARIABLE.getName()));
+                                               MODEL_VARIABLE.getName()));
             rConnection.voidEval(String.format(getClassificationFn,
                                                ProviderRObject.CLASSIFICATION_FN.getName(),
-                                               MODEL_VARIABLE.getName(),
-                                               INSTANCE_VARIABLE.getName()));
+                                               MODEL_VARIABLE.getName()));
 
         } catch (final RserveException e) {
             logger.error("Unable to prepare the workspace. Error found: " + rConnection.getLastError());

--- a/openml-caret/src/test/java/com/feedzai/openml/caret/CaretModelTest.java
+++ b/openml-caret/src/test/java/com/feedzai/openml/caret/CaretModelTest.java
@@ -21,7 +21,6 @@ import com.feedzai.util.provider.AbstractProviderCategoricalTargetTest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.feedzai.openml.r.ClassificationGenericRModel;
-import org.junit.Ignore;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -59,6 +58,11 @@ public class CaretModelTest extends AbstractProviderCategoricalTargetTest<Classi
     @Override
     public Instance getDummyInstance() {
         return new MockInstance(new double[]{1.0, 0.0, 3.0, 1.0, 22.0, 1.0, 0.0, 7.25, 0.0});
+    }
+
+    @Override
+    public Instance getDummyInstanceDifferentResult() {
+        return new MockInstance(new double[]{0.0, 1.0, 1.0, 0.0, 15.0, 0.0, 1.0, 2.57, 1.0});
     }
 
     @Override

--- a/openml-generic-r/README.md
+++ b/openml-generic-r/README.md
@@ -12,13 +12,13 @@ loadModel <- function() {
     stop("This must be implemented by a concrete provider")
 }
 
-# score the instance stored in the 'instance' global var and returns an array with the probability for each of the classes
-getClassDistribution <- function() {
+# score the instance and returns an array with the probability for each of the classes
+getClassDistribution <- function(instance) {
     stop("This must be implemented by a concrete provider")
 }
 
-# returns the predicted class of the instance stored in the 'instance' global var
-classify <- function() {
+# returns the predicted class of the instance
+classify <- function(instance) {
     stop("This must be implemented by a concrete provider")
 }
 ``` 

--- a/openml-generic-r/src/test/java/com/feedzai/openml/r/GenericRModelTest.java
+++ b/openml-generic-r/src/test/java/com/feedzai/openml/r/GenericRModelTest.java
@@ -32,7 +32,6 @@ import com.feedzai.util.algorithm.MLAlgorithmEnum;
 import com.feedzai.util.provider.AbstractProviderModelLoadTest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -93,6 +92,11 @@ public class GenericRModelTest extends AbstractProviderModelLoadTest<Classificat
     @Override
     public Instance getDummyInstance() {
         return new MockInstance(new double[]{1.0, 0.0});
+    }
+
+    @Override
+    public Instance getDummyInstanceDifferentResult() {
+        return new MockInstance(new double[]{0.0, 1.0});
     }
 
     @Override

--- a/openml-generic-r/src/test/resources/model0/scripts/classifier.R
+++ b/openml-generic-r/src/test/resources/model0/scripts/classifier.R
@@ -3,7 +3,9 @@ loadModel <- function() {
 }
 
 getClassDistribution <- function(instance) {
-    return(data.frame(a=0.3,b=0.7))
+    set.seed(instance[1,1])
+    aDist = runif(1)
+    return(data.frame(a = aDist, b = 1 - aDist))
 }
 
 classify <- function(instance) {

--- a/openml-generic-r/src/test/resources/model0/scripts/classifier.R
+++ b/openml-generic-r/src/test/resources/model0/scripts/classifier.R
@@ -2,10 +2,10 @@ loadModel <- function() {
     return(NULL)
 }
 
-getClassDistribution <- function() {
+getClassDistribution <- function(instance) {
     return(data.frame(a=0.3,b=0.7))
 }
 
-classify <- function() {
+classify <- function(instance) {
     return('a')
 }

--- a/openml-generic-r/src/test/resources/model1/scripts/classifier.R
+++ b/openml-generic-r/src/test/resources/model1/scripts/classifier.R
@@ -2,10 +2,10 @@ loadModel <- function() {
     return(NULL)
 }
 
-getClassDistribution <- function() {
+getClassDistribution <- function(instance) {
     return(data.frame(a=0.6,b=0.4))
 }
 
-classify <- function() {
+classify <- function(instance) {
     return('b')
 }

--- a/openml-generic-r/src/test/resources/model_not_valid/scripts/classifier.R
+++ b/openml-generic-r/src/test/resources/model_not_valid/scripts/classifier.R
@@ -1,7 +1,7 @@
-loadModel <- function() {
+loadModel <- function(instance) {
     return(NULL)
 }
 
-classify <- function() {
+classify <- function(instance) {
     return('b')
 }

--- a/openml-r-common/src/main/java/com/feedzai/openml/r/ClassificationGenericRModel.java
+++ b/openml-r-common/src/main/java/com/feedzai/openml/r/ClassificationGenericRModel.java
@@ -162,11 +162,13 @@ public class ClassificationGenericRModel implements ClassificationMLModel {
      * @return The result of the expression.
      * @throws RserveException If anything goes wrong during the execution of R code.
      * @throws REXPMismatchException If there is an error during the creation of the data frame.
+     * @see <a href="http://rforge.net/Rserve/">Rserve</a>
      */
     private synchronized REXP evaluateInstance(final String function,
                                                final Instance instance) throws RserveException, REXPMismatchException {
-        this.rConnection.assign(ProviderRObject.INSTANCE_VARIABLE.getName(), convertInstanceToDataFrame(instance));
-        return this.rConnection.eval(String.format("%s(%s)", function, ProviderRObject.INSTANCE_VARIABLE.getName()));
+        final String instanceRVar = "instance";
+        this.rConnection.assign(instanceRVar, convertInstanceToDataFrame(instance));
+        return this.rConnection.eval(String.format("%s(%s)", function, instanceRVar));
     }
 
     /**

--- a/openml-r-common/src/main/java/com/feedzai/openml/r/ClassificationGenericRModel.java
+++ b/openml-r-common/src/main/java/com/feedzai/openml/r/ClassificationGenericRModel.java
@@ -89,8 +89,10 @@ public class ClassificationGenericRModel implements ClassificationMLModel {
     @Override
     public double[] getClassDistribution(final Instance instance) {
         try {
-            createEvent(instance);
-            final RList list = executeEvalInRserveConnection(ProviderRObject.CLASS_DISTRIBUTION_FN.getName() + "()").asList();
+            final RList list = evaluateInstance(
+                    ProviderRObject.CLASS_DISTRIBUTION_FN.getName(),
+                    instance
+            ).asList();
 
             final Set<String> targetValues = getTargetValues();
             final double[] classDistribution = new double[targetValues.size()];
@@ -108,8 +110,10 @@ public class ClassificationGenericRModel implements ClassificationMLModel {
     @Override
     public int classify(final Instance instance) {
         try {
-            createEvent(instance);
-            final String predictedClass = executeEvalInRserveConnection(ProviderRObject.CLASSIFICATION_FN.getName() + "()").asString();
+            final String predictedClass = evaluateInstance(
+                    ProviderRObject.CLASSIFICATION_FN.getName(),
+                    instance
+            ).asString();
             return Iterables.indexOf(getTargetValues(), predictedClass::equals);
 
         } catch (final Exception e) {
@@ -148,26 +152,21 @@ public class ClassificationGenericRModel implements ClassificationMLModel {
     }
 
     /**
-     * Uses the connection to Rserve to execute a expression. This method needs to be synchronized because the
-     * connection to Rserve isn't thread-safe.
+     * Calls a R {@code function} to evaluate an {@code instance}.
+     * This function depends on the {@link RConnection connection to Rserve} to run R code. The connection to Rserve
+     * isn't thread-safe and so this method needs to be synchronized.
      *
-     * @param expression The expression to execute.
+     * @param function Name of the R function to evaluate an instance. It's assumed that this function only receives
+     *                 one parameter.
+     * @param instance The instance to be evaluated.
      * @return The result of the expression.
-     * @throws RserveException If anything goes wrong.
+     * @throws RserveException If anything goes wrong during the execution of R code.
+     * @throws REXPMismatchException If there is an error during the creation of the data frame.
      */
-    private synchronized REXP executeEvalInRserveConnection(final String expression) throws RserveException {
-        return this.rConnection.eval(expression);
-    }
-
-    /**
-     * Creates a new variable in R with the {@code instance} to classify.
-     *
-     * @param instance The instance to classify.
-     * @throws RserveException If there is an error with the connection to Rserve.
-     * @throws REXPMismatchException If it cannot convert an object to an expected type.
-     */
-    private synchronized void createEvent(final Instance instance) throws RserveException, REXPMismatchException {
+    private synchronized REXP evaluateInstance(final String function,
+                                               final Instance instance) throws RserveException, REXPMismatchException {
         this.rConnection.assign(ProviderRObject.INSTANCE_VARIABLE.getName(), convertInstanceToDataFrame(instance));
+        return this.rConnection.eval(String.format("%s(%s)", function, ProviderRObject.INSTANCE_VARIABLE.getName()));
     }
 
     /**

--- a/openml-r-common/src/main/java/com/feedzai/openml/r/ProviderRObject.java
+++ b/openml-r-common/src/main/java/com/feedzai/openml/r/ProviderRObject.java
@@ -32,10 +32,6 @@ public enum ProviderRObject {
      */
     MODEL_VARIABLE("model"),
     /**
-     * Name of the variable used in R to refer to the instance to be classified by the model.
-     */
-    INSTANCE_VARIABLE("instance"),
-    /**
      * Name of the function used in R to load a model.
      */
     LOAD_MODEL_FN("loadModel"),

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <openml-api.version>0.1.0</openml-api.version>
+        <openml-api.version>0.1.1</openml-api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Fixes #17 by changing the R functions used to classify instances to receive a new parameter with the instance to be classified. The conversion of an instance to data frame was moved to be called inside the synchronized method used to evaluate the instance.