### PR TITLE
Replace serviceLoader declaration by google auto-service plugin

### DIFF
--- a/openml-caret/pom.xml
+++ b/openml-caret/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>openml-utils</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.feedzai</groupId>
             <artifactId>openml-utils</artifactId>
             <type>test-jar</type>

--- a/openml-caret/src/main/java/com/feedzai/openml/caret/CaretModelProvider.java
+++ b/openml-caret/src/main/java/com/feedzai/openml/caret/CaretModelProvider.java
@@ -13,6 +13,7 @@ import com.feedzai.openml.model.MachineLearningModel;
 import com.feedzai.openml.provider.MachineLearningProvider;
 import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
 import com.feedzai.openml.util.algorithm.MLAlgorithmEnum;
+import com.google.auto.service.AutoService;
 
 import java.util.Optional;
 import java.util.Set;
@@ -25,6 +26,7 @@ import java.util.Set;
  * @author Paulo Pereira (paulo.pereira@feedzai.com)
  * @since 0.1.0
  */
+@AutoService(MachineLearningProvider.class)
 public class CaretModelProvider implements MachineLearningProvider<CaretModelLoader> {
 
     /**

--- a/openml-caret/src/main/resources/META-INF/services/com.feedzai.openml.provider.MachineLearningProvider
+++ b/openml-caret/src/main/resources/META-INF/services/com.feedzai.openml.provider.MachineLearningProvider
@@ -1,9 +1,0 @@
-#
-# The copyright of this file belongs to Feedzai. The file cannot be
-# reproduced in whole or in part, stored in a retrieval system,
-# transmitted in any form, or by any means electronic, mechanical,
-# photocopying, or otherwise, without the prior permission of the owner.
-#
-# (c) 2018 Feedzai, Strictly Confidential
-#
-com.feedzai.openml.caret.CaretModelProvider

--- a/openml-generic-r/pom.xml
+++ b/openml-generic-r/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/openml-generic-r/src/main/java/com/feedzai/openml/r/RModelProvider.java
+++ b/openml-generic-r/src/main/java/com/feedzai/openml/r/RModelProvider.java
@@ -25,6 +25,7 @@ import com.feedzai.openml.provider.MachineLearningProvider;
 import com.feedzai.openml.provider.descriptor.MLAlgorithmDescriptor;
 import com.feedzai.openml.util.algorithm.GenericAlgorithm;
 import com.feedzai.openml.util.algorithm.MLAlgorithmEnum;
+import com.google.auto.service.AutoService;
 
 import java.util.Optional;
 import java.util.Set;
@@ -37,6 +38,7 @@ import java.util.Set;
  * @author Paulo Pereira (paulo.pereira@feedzai.com)
  * @since 0.1.0
  */
+@AutoService(MachineLearningProvider.class)
 public class RModelProvider implements MachineLearningProvider<GenericRModelLoader> {
 
     /**

--- a/openml-generic-r/src/main/resources/META-INF/services/com.feedzai.openml.provider.MachineLearningProvider
+++ b/openml-generic-r/src/main/resources/META-INF/services/com.feedzai.openml.provider.MachineLearningProvider
@@ -1,9 +1,0 @@
-#
-# The copyright of this file belongs to Feedzai. The file cannot be
-# reproduced in whole or in part, stored in a retrieval system,
-# transmitted in any form, or by any means electronic, mechanical,
-# photocopying, or otherwise, without the prior permission of the owner.
-#
-# (c) 2018 Feedzai, Strictly Confidential
-#
-com.feedzai.openml.r.RModelProvider

--- a/pom.xml
+++ b/pom.xml
@@ -103,15 +103,15 @@
                 <version>${openml-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.auto.service</groupId>
+                <artifactId>auto-service</artifactId>
+                <version>1.0-rc2</version>
+            </dependency>
+            <dependency>
                 <groupId>com.feedzai</groupId>
                 <artifactId>openml-utils</artifactId>
                 <version>${openml-api.version}</version>
                 <type>test-jar</type>
-            </dependency>
-            <dependency>
-                <groupId>com.feedzai</groupId>
-                <artifactId>openml-example</artifactId>
-                <version>${openml-api.version}</version>
             </dependency>
 
             <!--Apache commons-->


### PR DESCRIPTION
OpenML relies on [Java Service Loader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) for being loaded dynamically on the Feedzai platform.

A common problem when developing such using Java Service loader  is a developer forgetting the service declaration file, and needing to spend some time debugging why the provider is not being loaded just to find out it forgot the file, or there's a small typo.

 If someone new to OpenML (or service loader) tries to create a new provider, it may forget to create the file and hit this problem. 

Since we recommend this plugin on our documentation (https://github.com/feedzai/feedzai-openml#developing), this PR makes us "eat our own dog food".