### PR TITLE
Validate a model before loading

### DIFF
--- a/openml-r-common/src/main/java/com/feedzai/openml/r/GenericRModelLoader.java
+++ b/openml-r-common/src/main/java/com/feedzai/openml/r/GenericRModelLoader.java
@@ -29,6 +29,7 @@ import com.feedzai.openml.util.load.LoadSchemaUtils;
 import com.feedzai.openml.util.validate.ClassificationValidationUtils;
 import com.feedzai.openml.util.validate.ValidationUtils;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.rosuda.REngine.REXPMismatchException;
 import org.rosuda.REngine.Rserve.RConnection;
 import org.rosuda.REngine.Rserve.RserveException;
@@ -68,6 +69,7 @@ public class GenericRModelLoader implements MachineLearningModelLoader<Classific
                                                  final DatasetSchema schema) throws ModelLoadingException {
 
         logger.info(String.format("Trying to load a model in path [%s]...", modelPath));
+        ClassificationValidationUtils.validateParamsModelToLoad(this, modelPath, schema, ImmutableMap.of());
 
         final RConnection rConnection;
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <openml-api.version>0.2.1</openml-api.version>
+        <openml-api.version>0.3.0</openml-api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
When a model is loaded we were assuming that whoever calls it already called the method to validate the model to load which might or not be true. This commit improves the method responsible to load the  model to validate the model before loading  it.