### PR TITLE
Make OpenML dependencies provided so that they are not part of the OpenML uber jars

### DIFF
--- a/openml-caret/pom.xml
+++ b/openml-caret/pom.xml
@@ -37,10 +37,12 @@
         <dependency>
             <groupId>com.feedzai</groupId>
             <artifactId>openml-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.feedzai</groupId>
             <artifactId>openml-utils</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.auto.service</groupId>
@@ -50,6 +52,7 @@
             <groupId>com.feedzai</groupId>
             <artifactId>openml-utils</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/openml-generic-r/pom.xml
+++ b/openml-generic-r/pom.xml
@@ -40,6 +40,16 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.feedzai</groupId>
+            <artifactId>openml-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.feedzai</groupId>
+            <artifactId>openml-utils</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>

--- a/openml-r-common/pom.xml
+++ b/openml-r-common/pom.xml
@@ -37,15 +37,18 @@
         <dependency>
             <groupId>com.feedzai</groupId>
             <artifactId>openml-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.feedzai</groupId>
             <artifactId>openml-utils</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.feedzai</groupId>
             <artifactId>openml-utils</artifactId>
             <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Make OpenML dependencies provided so that they are not part of the OpenML uber jars

This then allows the users to rely on a single openml api
version (that may be a superset usable by all used providers)
instead of 1 provider having internally a fixed openml api
version that is not good enough for all providers.

E.g.:
 * openml-api 0.2.2 has a new method
 * openml-provider-A depends on openml-api 0.2.2 and uses that method
 * openml-provider-B depends on openml-api 0.2.1 and does not care about that method

If openml-provider-B embeds openml-api (in that case 0.2.1) it can
'overtake' the openml-api 0.2.2 (that the user directly depends on)
and cause openml-provider-A to fail.