### PR TITLE
Bump OpenML API version to version 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <openml-api.version>0.3.0</openml-api.version>
+        <openml-api.version>1.0.0</openml-api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Summary:
Since the API breakages did not intersect with the code of this repo, no additional change was required.