### PR TITLE
Bump OpenML API to version 1.0.1

### DIFF
--- a/openml-r-common/src/main/java/com/feedzai/openml/r/GenericRModelLoader.java
+++ b/openml-r-common/src/main/java/com/feedzai/openml/r/GenericRModelLoader.java
@@ -67,7 +67,6 @@ public class GenericRModelLoader implements MachineLearningModelLoader<Classific
     @Override
     public ClassificationGenericRModel loadModel(final Path modelPath,
                                                  final DatasetSchema schema) throws ModelLoadingException {
-
         logger.info(String.format("Trying to load a model in path [%s]...", modelPath));
         ClassificationValidationUtils.validateParamsModelToLoad(this, modelPath, schema, ImmutableMap.of());
 
@@ -95,7 +94,14 @@ public class GenericRModelLoader implements MachineLearningModelLoader<Classific
     public List<ParamValidationError> validateForLoad(final Path modelPath,
                                                       final DatasetSchema schema,
                                                       final Map<String, String> params) {
-        return ValidationUtils.baseLoadValidations(schema, params);
+        final ImmutableList.Builder<ParamValidationError> builder = ImmutableList.builder();
+
+        builder.addAll(ValidationUtils.baseLoadValidations(schema, params));
+        if (!schema.getTargetFieldSchema().isPresent()) {
+            builder.add(new ParamValidationError("R Models must refer a target field in the correspondent schema."));
+        }
+
+        return builder.build();
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <openml-api.version>1.0.0</openml-api.version>
+        <openml-api.version>1.0.1</openml-api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Summary:
Since OpenML 1.0.0 had some missing changes, this commits bumps the version to 1.0.1 and adapts the code the new changes