### PR TITLE
Change wrong copyright notices to the correct ones

### DIFF
--- a/openml-caret/src/main/java/com/feedzai/openml/caret/CaretAlgorithm.java
+++ b/openml-caret/src/main/java/com/feedzai/openml/caret/CaretAlgorithm.java
@@ -1,10 +1,21 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * This software is licensed under the Apache License, Version 2.0 (the "Apache License") or the GNU
+ * Lesser General Public License version 3 (the "GPL License"). You may choose either license to govern
+ * your use of this software only upon the condition that you accept all of the terms of either the Apache
+ * License or the LGPL License.
+ *
+ * You may obtain a copy of the Apache License and the LGPL License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Apache License
+ * or the LGPL License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the Apache License and the LGPL License for the specific language governing
+ * permissions and limitations under the Apache License and the LGPL License.
+ *
  */
 
 package com.feedzai.openml.caret;

--- a/openml-caret/src/main/java/com/feedzai/openml/caret/CaretModelLoader.java
+++ b/openml-caret/src/main/java/com/feedzai/openml/caret/CaretModelLoader.java
@@ -1,10 +1,21 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * This software is licensed under the Apache License, Version 2.0 (the "Apache License") or the GNU
+ * Lesser General Public License version 3 (the "GPL License"). You may choose either license to govern
+ * your use of this software only upon the condition that you accept all of the terms of either the Apache
+ * License or the LGPL License.
+ *
+ * You may obtain a copy of the Apache License and the LGPL License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Apache License
+ * or the LGPL License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the Apache License and the LGPL License for the specific language governing
+ * permissions and limitations under the Apache License and the LGPL License.
+ *
  */
 
 package com.feedzai.openml.caret;

--- a/openml-caret/src/main/java/com/feedzai/openml/caret/CaretModelProvider.java
+++ b/openml-caret/src/main/java/com/feedzai/openml/caret/CaretModelProvider.java
@@ -1,10 +1,21 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * This software is licensed under the Apache License, Version 2.0 (the "Apache License") or the GNU
+ * Lesser General Public License version 3 (the "GPL License"). You may choose either license to govern
+ * your use of this software only upon the condition that you accept all of the terms of either the Apache
+ * License or the LGPL License.
+ *
+ * You may obtain a copy of the Apache License and the LGPL License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Apache License
+ * or the LGPL License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the Apache License and the LGPL License for the specific language governing
+ * permissions and limitations under the Apache License and the LGPL License.
+ *
  */
 
 package com.feedzai.openml.caret;

--- a/openml-caret/src/main/java/com/feedzai/openml/caret/package-info.java
+++ b/openml-caret/src/main/java/com/feedzai/openml/caret/package-info.java
@@ -1,10 +1,21 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * This software is licensed under the Apache License, Version 2.0 (the "Apache License") or the GNU
+ * Lesser General Public License version 3 (the "GPL License"). You may choose either license to govern
+ * your use of this software only upon the condition that you accept all of the terms of either the Apache
+ * License or the LGPL License.
+ *
+ * You may obtain a copy of the Apache License and the LGPL License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Apache License
+ * or the LGPL License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the Apache License and the LGPL License for the specific language governing
+ * permissions and limitations under the Apache License and the LGPL License.
+ *
  */
 
 /**

--- a/openml-caret/src/test/java/com/feedzai/openml/caret/CaretModelTest.java
+++ b/openml-caret/src/test/java/com/feedzai/openml/caret/CaretModelTest.java
@@ -1,10 +1,21 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * This software is licensed under the Apache License, Version 2.0 (the "Apache License") or the GNU
+ * Lesser General Public License version 3 (the "GPL License"). You may choose either license to govern
+ * your use of this software only upon the condition that you accept all of the terms of either the Apache
+ * License or the LGPL License.
+ *
+ * You may obtain a copy of the Apache License and the LGPL License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ * http://www.gnu.org/licenses/lgpl-3.0.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Apache License
+ * or the LGPL License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the Apache License and the LGPL License for the specific language governing
+ * permissions and limitations under the Apache License and the LGPL License.
+ *
  */
 
 package com.feedzai.openml.caret;


### PR DESCRIPTION
Some files are not using the correct copyright notice. In order to fix this, the copyright notices were changed.