### PR TITLE
Prepare code for more recent versions of Guava

### DIFF
--- a/openml-caret/pom.xml
+++ b/openml-caret/pom.xml
@@ -44,6 +44,14 @@
             <artifactId>openml-utils</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <!--Guava-->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>

--- a/openml-generic-r/pom.xml
+++ b/openml-generic-r/pom.xml
@@ -64,6 +64,13 @@
             <artifactId>auto-service</artifactId>
         </dependency>
 
+        <!--Guava-->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>

--- a/openml-r-common/pom.xml
+++ b/openml-r-common/pom.xml
@@ -69,6 +69,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!--Guava-->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.source>1.8</project.source>
-        <guava.version>18.0</guava.version>
         <commons-io.version>2.4</commons-io.version>
         <junit.version>4.12</junit.version>
         <logback.version>1.2.3</logback.version>
@@ -121,11 +120,13 @@
                 <version>${commons-io.version}</version>
             </dependency>
 
-            <!--Guava-->
+            <!-- Use the same dependencies versions of openml-api -->
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
+                <groupId>com.feedzai</groupId>
+                <artifactId>openml</artifactId>
+                <version>${openml-api.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
 
             <!--Logging -->


### PR DESCRIPTION
While upgrading guava to version 29-jre some methods where removed. Since we can't release a version with guava upgraded yet we can already remove the use of deprecated methods, and replace it with similar methods.

We also change the way that dependencies are managed to get the versions that openml-api uses.